### PR TITLE
status bar style support added

### DIFF
--- a/LRScrollingSidebarController/LRScrollingSidebarController.h
+++ b/LRScrollingSidebarController/LRScrollingSidebarController.h
@@ -51,6 +51,8 @@ typedef UIViewController<LRScrollingSidebarController> *ISSidePanelController;
 
 @property (nonatomic) BOOL allowBouncing;
 @property (nonatomic) BOOL allowParallax;
+@property (nonatomic) UIStatusBarStyle statusbarStyle;
+@property(nonatomic, getter=isStatusBarHidden) BOOL statusBarHidden;
 
 @property (nonatomic, weak) id<LRScrollingSidebarControllerDelegate> delegate;
 

--- a/LRScrollingSidebarController/LRScrollingSidebarController.m
+++ b/LRScrollingSidebarController/LRScrollingSidebarController.m
@@ -94,6 +94,7 @@ static CGFloat const kMainViewControllerOverlayMaxAlpha = 0.9f;
     [self buildUpMainHierarchy];
     [self showInitialPanel];
     [self activateScrollingSidebarNavigation];
+    [self updateStatusBarStyle];
 }
 
 - (void)showInitialPanel
@@ -306,6 +307,7 @@ static CGFloat const kMainViewControllerOverlayMaxAlpha = 0.9f;
     
     [self applyParallaxEffect];
     [self applyOverlayEffect];
+    [self updateStatusBarStyle];
 }
 
 - (void)applyParallaxEffect
@@ -413,6 +415,37 @@ static CGFloat const kMainViewControllerOverlayMaxAlpha = 0.9f;
 - (NSUInteger)supportedInterfaceOrientations
 {
     return UIInterfaceOrientationMaskPortrait;
+}
+
+#pragma mark - status bar
+
+// allows to use the child's StatusBar
+- (UIViewController *)childViewControllerForStatusBarStyle
+{
+    return [self visibleController];
+}
+
+- (UIViewController *)childViewControllerForStatusBarHidden
+{
+    return [self visibleController];
+}
+
+- (void)updateStatusBarStyle
+{
+    if ([self respondsToSelector:@selector(setNeedsStatusBarAppearanceUpdate)]) {
+        [self setNeedsStatusBarAppearanceUpdate];
+    }
+}
+
+// adjust the style of the base status bar while the app is running
+- (UIStatusBarStyle)preferredStatusBarStyle
+{
+    return self.statusbarStyle;
+}
+
+-(BOOL) prefersStatusBarHidden
+{
+    return self.isStatusBarHidden;
 }
 
 @end

--- a/README.md
+++ b/README.md
@@ -109,6 +109,24 @@ The category UIViewController+LRScrollingSidebarController aims at making every 
 ```
 [self.scrollingSidebarController showMainViewControllerAnimated:YES];
 ```
+Additionally you can change or hide the initial status bar
+
+```
+@property (nonatomic) UIStatusBarStyle statusbarStyle;
+@property(nonatomic, getter=isStatusBarHidden) BOOL statusBarHidden;
+```
+Or change it or hide it individually from each of your child controllers by adding one of these two methods
+
+```
+- (UIStatusBarStyle)preferredStatusBarStyle {
+    return UIStatusBarStyleLightContent;
+}
+
+-(BOOL) prefersStatusBarHidden {
+    return YES;
+}
+```
+Note: we are assuming that your "View controller-based status bar appearance" in your info.plist is set to YES
 
 ### Requirements
 


### PR DESCRIPTION
Now you can change or hide the initial status bar style

```
@property (nonatomic) UIStatusBarStyle statusbarStyle;
@property(nonatomic, getter=isStatusBarHidden) BOOL statusBarHidden;
```

Or change it or hide it individually from each of your child controllers by adding one of these two methods

```
- (UIStatusBarStyle)preferredStatusBarStyle {
    return UIStatusBarStyleLightContent;
}

-(BOOL) prefersStatusBarHidden {
    return YES;
}
```

Note: we are assuming that your "View controller-based status bar appearance" in your info.plist is set to YES
